### PR TITLE
feature: Use canonical upload URL & provide docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ ChangeLog
 1.0.0b1 (In Development)
 ========================
 
-- Add docs
+- Add brief documentation
+- Use canonical upload URL for tus config mapping
 
 1.0.0b0 (2020-03-15)
 ====================

--- a/aiohttp_tus/__init__.py
+++ b/aiohttp_tus/__init__.py
@@ -2,4 +2,4 @@ from .tus import setup_tus
 
 __all__ = ("setup_tus",)
 __license__ = "BSD-3-Clause"
-__version__ = "1.0.0b0"
+__version__ = "1.0.0b1"

--- a/aiohttp_tus/data.py
+++ b/aiohttp_tus/data.py
@@ -57,6 +57,19 @@ class Config:
 
 @attr.dataclass(frozen=True, slots=True)
 class Resource:
+    """Dataclass to store resource metadata.
+
+    Given dataclass used internally in between resource chunk uploads and is passed
+    to ``on_upload_done`` callback if one is defined at :func:`aiohttp_tus.setup_tus`
+    call.
+
+    :param uid: Resource UUID. By default: ``str(uuid.uuid4())``
+    :param file_name: Resource file name.
+    :param file_size: Resource file size.
+    :param offset: Current resource offset.
+    :param metadata_header: Metadata header sent on initiating resource upload.
+    """
+
     file_name: str
     file_size: int
     offset: int
@@ -130,7 +143,7 @@ class Resource:
         return (path, data)
 
 
-ResourceCallback = Callable[[Resource, Path], Awaitable[None]]
+ResourceCallback = Callable[[web.Request, Resource, Path], Awaitable[None]]
 
 
 def delete_path(path: Path) -> bool:

--- a/aiohttp_tus/utils.py
+++ b/aiohttp_tus/utils.py
@@ -46,12 +46,12 @@ def get_resource_or_410(request: web.Request) -> Resource:
 
 
 async def on_upload_done(
-    *, config: Config, resource: Resource, file_path: Path
+    *, request: web.Request, config: Config, resource: Resource, file_path: Path
 ) -> None:
     if not config.on_upload_done:
         return
 
-    await config.on_upload_done(resource, file_path)
+    await config.on_upload_done(request, resource, file_path)
 
 
 def parse_upload_metadata(metadata_header: str) -> MappingStrBytes:

--- a/aiohttp_tus/views.py
+++ b/aiohttp_tus/views.py
@@ -167,7 +167,9 @@ async def upload_resource(request: web.Request) -> web.Response:
     next_offset = resource.offset + chunk_size
     if next_offset == resource.file_size:
         file_path = resource.complete(config=config, match_info=match_info)
-        await on_upload_done(config=config, resource=resource, file_path=file_path)
+        await on_upload_done(
+            request=request, config=config, resource=resource, file_path=file_path
+        )
     # But if it is not - store new metadata
     else:
         next_resource = attr.evolve(resource, offset=next_offset)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,4 +2,5 @@
 API Reference
 =============
 
-TODO
+.. autofunction:: aiohttp_tus.setup_tus
+.. autoclass:: aiohttp_tus.data.Resource

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,4 +89,7 @@ texinfo_documents = [
     )
 ]
 
-intersphinx_mapping = {"https://docs.python.org/3/": None}
+intersphinx_mapping = {
+    "https://docs.python.org/3/": None,
+    "https://aiohttp.readthedocs.io/en/stable/": None,
+}

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,4 +2,102 @@
 Usage
 =====
 
-TODO
+Default
+=======
+
+To allow upload files to ``../uploads`` directory for all clients via ``/uploads`` URL,
+
+.. code-block:: python
+
+    from pathlib import Path
+
+    from aiohttp import web
+    from aiohttp_tus import setup_tus
+
+
+    app = setup_tus(
+        web.Application(),
+        upload_path=Path(__file__).parent.parent / "uploads"
+    )
+
+User Uploads
+============
+
+To allow upload files to ``/files/{username}`` directory only for authenticated users
+via ``/users/{username}/uploads`` URL,
+
+.. code-block:: python
+
+    from aiohttp_tus.annotations import Handler
+
+
+    def upload_user_required(handler: Handler) -> Handler:
+        async def decorator(request: web.Request) -> web.Response:
+            # Change ``is_user_authenticated`` call to actual call,
+            # checking whether user authetnicated for given request
+            # or not
+            if not is_user_authenticated(request):
+                raise web.HTTPForbidden()
+            return await handler(request)
+
+        return decorator
+
+
+    app = setup_tus(
+        web.Application(),
+        upload_path=Path("/files") / r"{username}",
+        upload_url=r"/users/{username}/uploads",
+        decorator=upload_user_required,
+    )
+
+Callback
+========
+
+There is a possibility to run any coroutine after upload is done. Example below,
+illustrates how to achieve that,
+
+.. code-block:: python
+
+    from aiohttp_tus.data import Resource
+
+
+    async def notify_on_upload(
+        request: web.Request,
+        resource: Resource,
+        file_path: Path,
+    ) -> None:
+        redis = request.config_dict["redis"]
+        await redis.rpush("uploaded_files", resource.file_name)
+
+
+    app = setup_tus(
+        web.Application(),
+        upload_path=Path(__file__).parent.parent / "uploads",
+        on_upload_done=notify_on_upload,
+    )
+
+Mutliple TUS upload URLs
+========================
+
+It is possible to setup multiple TUS upload URLs. Example below illustrates, how to
+achieve anonymous & authenticated uploads in same time for one
+:class:`aiohttp.web.Application` instance.
+
+.. code-block:: python
+
+    app = web.Application()
+    base_upload_path = Path(__file__).parent.parent / "uploads"
+
+    # Anonymous users uploads
+    setup_tus(
+        app,
+        upload_path=base_upload_path / "anonymous"
+    )
+
+    # Authenticated users uploads
+    setup_tus(
+        app,
+        upload_path=base_upload_path / r"{username}",
+        upload_url=r"/users/{username}/uploads",
+        decorator=upload_user_required,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ show_missing = true
 
 [tool.poetry]
 name = "aiohttp-tus"
-version = "1.0.0b0"
+version = "1.0.0b1"
 description = "tus.io protocol implementation for aiohttp.web applications"
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
One step closer to `1.0.0` release. Fix the issue with upload URL keys
for tus configs mapping and provide brief documentation, which covers
most of `aiohttp-tus` parts.