### PR TITLE
fix: add required Upload-Length header for upload resume

### DIFF
--- a/aiohttp_tus/views.py
+++ b/aiohttp_tus/views.py
@@ -43,6 +43,7 @@ async def resource_details(request: web.Request) -> web.Response:
             **constants.BASE_HEADERS,
             constants.HEADER_CACHE_CONTROL: "no-store",
             constants.HEADER_UPLOAD_OFFSET: str(resource.offset),
+            constants.HEADER_UPLOAD_LENGTH: str(resource.file_size),
         },
     )
 


### PR DESCRIPTION
### Issue
The missing header is causing resuming uploads to fail on the official client [uppy](https://github.com/transloadit/uppy)
The client keeps sending HEAD requests because the responses are missing the Upload-Length header and eventually fails with this error:
```
Failed because: tus: invalid or missing length value
```

### PR
This PR adds the `Upload-Length` header to the response

### Reasoning
According to the tus.io spec:
> If the size of the upload is known, the Server MUST include the Upload-Length header in the response.
ref: https://tus.io/protocols/resumable-upload.html#head