### PR TITLE
feature: Allow to provide custom upload resource name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ ChangeLog
 - Fix resuming uploads by passing missed ``Upload-Length`` header:
   `#5 <https://github.com/pylotcode/aiohttp-tus/pull/5>`_
 - Add documentation about `CORS Headers <https://aiohttp-tus.readthedocs.io/en/latest/usage.html#cors-headers>`_
+- Allow to provide upload resource name, which can be lately used for URL reversing
 
 1.0.0b2 (2020-03-18)
 ====================

--- a/aiohttp_tus/data.py
+++ b/aiohttp_tus/data.py
@@ -18,6 +18,8 @@ class Config:
     upload_path: Path
     upload_url: str
 
+    upload_resource_name: Optional[str] = None
+
     allow_overwrite_files: bool = False
     on_upload_done: Optional["ResourceCallback"] = None
 
@@ -41,11 +43,19 @@ class Config:
 
     @property
     def resource_tus_resource_name(self) -> str:
-        return f"tus_resource_{self.upload_url_id}"
+        return (
+            f"tus_resource_{self.upload_url_id}"
+            if self.upload_resource_name is None
+            else f"{self.upload_resource_name}_resource"
+        )
 
     @property
     def resource_tus_upload_name(self) -> str:
-        return f"tus_upload_{self.upload_url_id}"
+        return (
+            f"tus_upload_{self.upload_url_id}"
+            if self.upload_resource_name is None
+            else self.upload_resource_name
+        )
 
     @property
     def upload_url_id(self) -> str:
@@ -161,7 +171,7 @@ def get_config(request: web.Request) -> Config:
     info = route.get_info()
 
     config_key = info.get("formatter") or info["path"]
-    if route.resource.name.startswith("tus_resource_"):
+    if config_key.endswith(r"/{resource_uid}"):
         config_key = get_upload_url(config_key)
 
     try:

--- a/aiohttp_tus/tus.py
+++ b/aiohttp_tus/tus.py
@@ -14,6 +14,7 @@ def setup_tus(
     *,
     upload_path: Path,
     upload_url: str = "/uploads",
+    upload_resource_name: str = None,
     allow_overwrite_files: bool = False,
     decorator: Decorator = None,
     on_upload_done: ResourceCallback = None,
@@ -35,6 +36,10 @@ def setup_tus(
     :param upload_url:
         tus.io upload URL. Can be plain as ``/uploads`` or named as
         ``/users/{username}/uploads``. By default: ``"/uploads"``
+    :param upload_resource_name:
+        By default ``aiohttp-tus`` will provide auto name for the upload resource, as
+        well as for the chunk resource. But sometimes it might be useful to provide
+        exact name, which can lately be used for URL reversing.
     :param allow_overwrite_files:
         When enabled allow to overwrite already uploaded files. This may harm
         consistency of stored data, cause please use this param with caution. By
@@ -78,6 +83,7 @@ def setup_tus(
     config = Config(
         upload_path=upload_path,
         upload_url=upload_url,
+        upload_resource_name=upload_resource_name,
         allow_overwrite_files=allow_overwrite_files,
         on_upload_done=on_upload_done,
         json_dumps=json_dumps,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,5 +2,12 @@
 API Reference
 =============
 
+aiohttp_tus
+===========
+
 .. autofunction:: aiohttp_tus.setup_tus
+
+aiohttp_tus.data
+================
+
 .. autoclass:: aiohttp_tus.data.Resource

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -189,3 +189,39 @@ achieve anonymous & authenticated uploads in same time for one
         upload_url=r"/users/{username}/uploads",
         decorator=upload_user_required,
     )
+
+Upload resource name
+====================
+
+In most cases there is no need to specify :class:`aiohttp.web.Resource` name for upload
+resource, but when it is necessary, it is possible to specify custom
+``upload_resource_name`` and lately use it for URL reversing.
+
+Example below illustrates how to achieve it,
+
+In ``app.py``,
+
+.. code-block:: python
+
+    setup_tus(
+        web.Application(),
+        upload_path=(
+            Path(__file__).parent.parent / "uploads" / r"{username}"
+        ),
+        upload_url="/user/{username}/uploads",
+        upload_resource_name="user_upload",
+    )
+
+In ``views.py``,
+
+.. code-block:: python
+
+    async def user_profile(request: web.Request) -> web.Response:
+        upload_url = request.app.router["uploads"].url_for(
+            username=request.match_info["username"]
+        )
+        return aiohttp_jinja2.render(
+            "users/profile.html",
+            request,
+            {"upload_url": upload_url},
+        )


### PR DESCRIPTION
As sometimes it is useful to allow tus upload url to be URL reversed via
`request.app[<upload_resource_name>].url_for(...)`