### PR TITLE
Added support for use behind reverse proxy by propagating protocol

### DIFF
--- a/aiohttp_tus/constants.py
+++ b/aiohttp_tus/constants.py
@@ -23,3 +23,7 @@ BASE_HEADERS = {
     HEADER_TUS_RESUMABLE: TUS_API_VERSION,
     HEADER_TUS_VERSION: TUS_API_VERSION_SUPPORTED,
 }
+
+
+# Used to get original protocol from proxy servers (nginx, apache, etc.)
+HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto"


### PR DESCRIPTION
On the aiohttp documentation, they suggest running the server with Gunicorn behind a reverse proxy such as nginx.

However this creates an issue in the `Location` header in the response that is passed back by `aiohttp-tus` as the protocol (http or https) is not preserved

This causes the subsequent upload requests to attempt to connect through http instead of https.

In this PR I made aiohttp-tus use the standard header that is passed by reverse proxies to fix this: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto