### PR TITLE
chore: 1.0.0 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.0.0 (2020-06-08)
+==================
+
+- Final **1.0.0** release, which marks ``aiohttp-tus`` as library ready to be used in
+  production
+
 1.0.0rc1 (2020-04-02)
 =====================
 

--- a/aiohttp_tus/__init__.py
+++ b/aiohttp_tus/__init__.py
@@ -2,4 +2,4 @@ from .tus import setup_tus
 
 __all__ = ("setup_tus",)
 __license__ = "BSD-3-Clause"
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ show_missing = true
 
 [tool.poetry]
 name = "aiohttp-tus"
-version = "1.0.0rc1"
+version = "1.0.0"
 description = "tus.io protocol implementation for aiohttp.web applications"
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
- Final **1.0.0** release, which marks that `aiohttp-tus` library is ready to be used in production